### PR TITLE
Fix namespaced HTTPNotFoundError

### DIFF
--- a/lib/private_strategy.rb
+++ b/lib/private_strategy.rb
@@ -2,6 +2,8 @@ class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
   require "utils/formatter"
   require "utils/github"
 
+  GitHubHTTPNotFoundError = defined?(GitHub::API::HTTPNotFoundError) ? GitHub::API::HTTPNotFoundError : GitHub::HTTPNotFoundError
+
   def initialize(url, name, version, **meta)
     super
     parse_url_pattern
@@ -37,7 +39,7 @@ class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
 
   def validate_github_repository_access!
     GitHub.repository(@owner, @repo)
-  rescue GitHub::HTTPNotFoundError
+  rescue GitHubHTTPNotFoundError
     message = <<~EOS
       HOMEBREW_GITHUB_API_TOKEN can not access the repository: #{@owner}/#{@repo}
       This token may not have permission to access the repository or the url of formula may be incorrect.


### PR DESCRIPTION
Folks on newer homebrew and with a bad PAT will hit an error.

```
kamal@kmahyuddin-mbp diplomat-server % brew install k8sconfig
==> Fetching envoy/tools/k8sconfig
Error: uninitialized constant GitHub::HTTPNotFoundError
/opt/homebrew/Library/Taps/envoy/homebrew-tools/lib/private_strategy.rb:40:in `rescue in validate_github_repository_access!'
/opt/homebrew/Library/Taps/envoy/homebrew-tools/lib/private_strategy.rb:38:in `validate_github_repository_access!'
```

The change in homebrew was from 3 years ago https://github.com/Homebrew/brew/pull/10626